### PR TITLE
Change \cdot mapping

### DIFF
--- a/lua/cmp_latex_symbols/items.lua
+++ b/lua/cmp_latex_symbols/items.lua
@@ -50,7 +50,7 @@ local symbols = {
   {word="\\tcmu", label="\\tcmu µ", insertText="µ", filterText="\\tcmu"},
   {word="\\mathrm", label="\\mathrm µ", insertText="µ", filterText="\\mathrm"},
   {word="\\cdotp", label="\\cdotp ·", insertText="·", filterText="\\cdotp"},
-  {word="\\cdot", label="\\cdot ·", insertText="·", filterText="\\cdot"},
+  {word="\\cdot", label="\\cdot ⋅", insertText="⋅", filterText="\\cdot"},
   {word="\\times", label="\\times ×", insertText="×", filterText="\\times"},
   {word="\\eth", label="\\eth ð", insertText="ð", filterText="\\eth"},
   {word="\\matheth", label="\\matheth ð", insertText="ð", filterText="\\matheth"},


### PR DESCRIPTION
The original items.lua maps both \cdot and \cdotp to U+00B7. However, the unicode-math package (https://ctan.org/pkg/unicode-math), which is the de facto standard method to use Unicode math fonts with LATEX and therefore the de facto standard in mapping LATEX commands to Unicode code points as far as I know, maps \cdot to U+22C5 instead (http://mirrors.ctan.org/macros/unicodetex/latex/unicode-math/unimath-symbols.pdf).